### PR TITLE
PXB-1530: Invalid write of size 8 in xb_keyring_init_for_prepare

### DIFF
--- a/storage/innobase/xtrabackup/src/keyring_plugins.cc
+++ b/storage/innobase/xtrabackup/src/keyring_plugins.cc
@@ -194,7 +194,9 @@ xb_keyring_init_for_backup(MYSQL *connection)
 	mysql_free_result(mysql_result);
 
 	int t_argc = keyring_plugin_args.size() + 1;
-	char **t_argv = new char *[t_argc];
+	char **t_argv = new char *[t_argc + 1];
+
+	memset(t_argv, 0, sizeof(char *) * t_argc + 1);
 
 	t_argv[0] = (char *) "";
 	for (int i = 1; i < t_argc; i++) {
@@ -263,8 +265,9 @@ xb_keyring_init_for_stats(int argc, char **argv)
 	}
 
 	int t_argc = argc;
-	char **t_argv = new char *[t_argc];
+	char **t_argv = new char *[t_argc + 1];
 
+	memset(t_argv, 0, sizeof(char *) * t_argc + 1);
 	memcpy(t_argv, argv, sizeof(char *) * t_argc);
 
 	plugin_init(&t_argc, t_argv, PLUGIN_INIT_SKIP_PLUGIN_TABLE);
@@ -338,8 +341,9 @@ xb_keyring_init_for_prepare(int argc, char **argv)
 	}
 
 	int t_argc = argc;
-	char **t_argv = new char *[t_argc];
+	char **t_argv = new char *[t_argc + 1];
 
+	memset(t_argv, 0, sizeof(char *) * t_argc + 1);
 	memcpy(t_argv, argv, sizeof(char *) * t_argc);
 
 	plugin_init(&t_argc, t_argv, PLUGIN_INIT_SKIP_PLUGIN_TABLE);


### PR DESCRIPTION
xb_keyring_init_for_prepare didn't take into account
that my_handle_options writes 0 into argv past passed
argc.

Fix is to pass larger buffer to plugin_init to leave
room for NULL pointer at the end.